### PR TITLE
Explicit cast to int on line 190 of BMP280.py

### DIFF
--- a/BMP280/BMP280.py
+++ b/BMP280/BMP280.py
@@ -187,7 +187,7 @@ class BMP280(object):
             return 0
 
         p = 1048576 - adc_P;
-        p = (((p<<31) - var2)*3125) / var1;
+        p = int((((p<<31) - var2)*3125) / var1);
         var1 = ((self.cal_REGISTER_DIG_P9) * (p>>13) * (p>>13)) >> 25;
         var2 = ((self.cal_REGISTER_DIG_P8) * p) >> 19;
 


### PR DESCRIPTION
Using this little change, the module works both in python 2.x and 3.y